### PR TITLE
klte-common: Add /dev/alarm rule to device ueventd.qcom.rc

### DIFF
--- a/rootdir/etc/ueventd.qcom.rc
+++ b/rootdir/etc/ueventd.qcom.rc
@@ -28,6 +28,7 @@
 # the DIAG device node is not world writable/readable.
 /dev/diag                 0660   system     oem_2950
 
+/dev/alarm                0664   system     radio
 /dev/genlock              0666   system     system
 /dev/kgsl                 0666   system     system
 /dev/kgsl-3d0             0666   system     system


### PR DESCRIPTION
* AOSP removed this as a platform-wide rule since it is "...not
  present on Pixel devices". As it turns out, our RIL gets grumpy
  and won't latch a data connection if it cannot open the device.
* own/mode aligned to AOSP values from before the change

* E RILD    : ElapsedRealTime() Cannot open file /dev/alarm

* ref: LineageOS/android_system_core@16cdffe8c

Change-Id: Ib369e4b76653a412d75a3c8c37ee283f8c8e9239