### PR TITLE
klte-common: Shim libperipheral_client.so

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -54,7 +54,8 @@ TARGET_KERNEL_SOURCE := kernel/samsung/msm8974
 
 # Legacy BLOB Support
 TARGET_LD_SHIM_LIBS += \
-    /system/vendor/lib/hw/camera.vendor.msm8974.so|libshim_camera.so
+    /system/vendor/lib/hw/camera.vendor.msm8974.so|libshim_camera.so \
+    /system/vendor/lib/libperipheral_client.so|libshim_binder.so
 TARGET_PROCESS_SDK_VERSION_OVERRIDE += \
     /system/bin/mediaserver=22 \
     /system/vendor/bin/mm-qcamera-daemon=22 \

--- a/klte.mk
+++ b/klte.mk
@@ -88,6 +88,10 @@ PRODUCT_PACKAGES += \
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/configs/sensors/_hals.conf:$(TARGET_COPY_OUT_VENDOR)/etc/sensors/_hals.conf
 
+# Shims
+PRODUCT_PACKAGES += \
+    libshim_binder
+
 # Shipping API level
 $(call inherit-product, $(SRC_TARGET_DIR)/product/product_launched_with_k.mk)
 


### PR DESCRIPTION
* LocSvc_afw: get_geofence_interface, dlopen for libgeofence.so
  failed, error = dlopen failed: cannot locate symbol
  "_ZN7android10IInterface8asBinderEv" referenced by
  "/system/vendor/lib/libperipheral_client.so"...
* vndksupport: Could not load /vendor/lib/hw/flp.default.so from
  default namespace: dlopen failed: cannot locate symbol
  "_ZN7android10IInterface8asBinderEv" referenced by
  "/system/vendor/lib/libperipheral_client.so"....

Change-Id: I4fed5fc23b1721e75e9759c0811b7532c5b68705