### PR TITLE
klte-common: Split Radio/QC Framework blobs into new blob list

### DIFF
--- a/common-proprietary-files-ril-m.txt
+++ b/common-proprietary-files-ril-m.txt
@@ -1,0 +1,27 @@
+# Samsung Package Version: G900FXXU1CSA1_G900FVIA1CSC1_VIA, unless pinned
+
+# Qualcomm Framework
+lib/libmdmdetect.so:vendor/lib/libmdmdetect.so
+vendor/lib/libconfigdb.so
+vendor/lib/libdiag.so
+vendor/lib/libdsutils.so
+vendor/lib/libidl.so
+vendor/lib/libnetmgr.so
+vendor/lib/libqcci_legacy.so
+vendor/lib/libqmi.so
+vendor/lib/libqmi_cci.so
+vendor/lib/libqmi_client_qmux.so
+vendor/lib/libqmi_common_so.so
+vendor/lib/libqmi_csi.so
+vendor/lib/libqmi_encdec.so
+vendor/lib/libqmiservices.so
+
+# Radio
+bin/efsks:vendor/bin/efsks
+bin/ks:vendor/bin/ks
+bin/qcks:vendor/bin/qcks
+bin/qmuxd:vendor/bin/qmuxd
+bin/rfs_access:vendor/bin/rfs_access
+bin/rmt_storage:vendor/bin/rmt_storage
+lib/libprotobuf-cpp-full.so:vendor/lib/libprotobuf-cpp-haxx.so
+vendor/lib/libril-qcril-hook-oem.so

--- a/common-proprietary-files.txt
+++ b/common-proprietary-files.txt
@@ -240,32 +240,9 @@ vendor/lib/libqti-perfd-client.so
 vendor/lib/libxml.so
 
 # Qualcomm Framework - Pinned to G900FXXS1BPCL_G900FOXA1BOJ1_BTU
-lib/libmdmdetect.so:vendor/lib/libmdmdetect.so|9c19d5aacc094597c166529386f83ac721ac1979
 lib/libperipheral_client.so:vendor/lib/libperipheral_client.so|7107a8e656fabc5ff6b7a33740be80a1add6abbd
-vendor/lib/libconfigdb.so|a7eedfbb0ffa070c9239f0d293262e268342da1d
-vendor/lib/libdiag.so|2dd30d2de57567aa4575f98e4679cdbd625bbbe6
 vendor/lib/libdsi_netctrl.so|d5d25fd5b1ea250bdfcb64059eafaf609fe2e32c
-vendor/lib/libdsutils.so|99fac25d6a10ea89a7f66cfc7c3a36478a178568
-vendor/lib/libidl.so|9b871bda84a1204b35b5a93311d666aa36a7f8b8
-vendor/lib/libnetmgr.so|fc8dcd60b4fd28518e03949842dd6b496712c2d1
-vendor/lib/libqcci_legacy.so|5f0f25a72677d0b3183031490e45b6de26735327
 vendor/lib/libqdi.so|6bd79ba4dc4b4af654cda666e829312ba07a22e9
-vendor/lib/libqmi.so|d120b126ba94cb2d4164243ef7a8516168b6fedf
-vendor/lib/libqmi_cci.so|b94c84c54183e538a7802ca531da7cf2b8176614
-vendor/lib/libqmi_client_qmux.so|79cb7b305bd9f87c581f26c805f4ca2bbdf3a069
-vendor/lib/libqmi_common_so.so|6c70d0c23898f4d5aa5a962736a06aa3d21e7aa6
-vendor/lib/libqmi_csi.so|dee249a1f0fff082b5e5547cfab103ac10ab55e2
-vendor/lib/libqmi_encdec.so|82e39ae7e4bb8651d06fdae99fc38e3fb390b62d
-vendor/lib/libqmiservices.so|0b90d67d7ec0b0bc3de2b5ccc3afcda13bd5ffd8
-
-# Radio - Pinned to G900FXXS1BPCL_G900FOXA1BOJ1_BTU
-bin/efsks:vendor/bin/efsks|2c366ac7ab878068c77e5598c411a48cf47b056a
-bin/ks:vendor/bin/ks|949406ae5d1b74034b3828af1905a181e4b69961
-bin/qcks:vendor/bin/qcks|9026c84f32e1ee5121024c72b878c09dfde95e5b
-bin/qmuxd:vendor/bin/qmuxd|e257d63996812e2eb23810bda59913f558ee03d2
-bin/rfs_access:vendor/bin/rfs_access|49a8516ed01b609a9e5079d8135b75db5b024236
-bin/rmt_storage:vendor/bin/rmt_storage|000ddcabfc9416e9a27ba6d04860cc14b6803cdd
-vendor/lib/libril-qcril-hook-oem.so|6a73ed46f4fbcb283eea5fb44b24a7d14522bfe5
 
 # Sensors
 lib/hw/sensors.msm8974.so:vendor/lib/hw/sensors.vendor.msm8974.so|48c6112bc4097e9176fcd53bf3f7ba0d643b27aa

--- a/extract-files.sh
+++ b/extract-files.sh
@@ -52,6 +52,7 @@ setup_vendor "$DEVICE_COMMON" "$VENDOR" "$CM_ROOT" true
 
 extract "$MY_DIR"/common-proprietary-files.txt "$SRC"
 extract "$MY_DIR"/common-proprietary-files-pn547.txt "$SRC"
+extract "$MY_DIR"/common-proprietary-files-ril-m.txt "$SRC"
 
 COMMON_BLOB_ROOT="$CM_ROOT"/vendor/"$VENDOR"/"$DEVICE_COMMON"/proprietary
 

--- a/setup-makefiles.sh
+++ b/setup-makefiles.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Copyright (C) 2016 The CyanogenMod Project
-# Copyright (C) 2017 The LineageOS Project
+# Copyright (C) 2017-2020 The LineageOS Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,6 +42,13 @@ write_headers "klte klteactivexx kltechn kltechnduo klteduos kltedv kltekdi klte
 write_makefiles "$MY_DIR"/common-proprietary-files.txt
 
 write_footers
+
+# This is the "common" M radio/QC framework stack. Most variants will inherit
+# this file. If they cannot then they will ship their own stack
+PRODUCTMK="$(echo $PRODUCTMK | sed -e 's|-vendor.mk|-vendor-ril-m.mk|g')"
+write_makefile_header "$PRODUCTMK"
+parse_file_list "$MY_DIR"/common-proprietary-files-ril-m.txt
+write_product_copy_files
 
 if [ ! -z $VARIANT_COPYRIGHT_YEAR ]; then
     export INITIAL_COPYRIGHT_YEAR=$VARIANT_COPYRIGHT_YEAR


### PR DESCRIPTION
* These allow for a "common" M-based set of blobs to be optionally
  included by child trees.

Change-Id: Iceb9333398cbaf6d11f7ca892b4aac7f7d4c67d3